### PR TITLE
Nick/adding install instructions links

### DIFF
--- a/week1_welcome/README.md
+++ b/week1_welcome/README.md
@@ -1,32 +1,35 @@
 # Hours with Experts - Week 1: Environment Setup
 
-To set up your environment, we are going to install the following:
+To set up your development environment, we are going to install software and setup environment variables. To complete the environment setup:
 
-* Python 3.10: must be exactly this version
+- Follow these [instructions for Windows](setup-windows.md)
+- Follow these [instructions for Macs](setup-mac.md)
+
+## Environment Setup Overview
+The instructions linked above will configure the following software and environment settings. 
+
+### Environment Setup - Software
+* Python 3.10.11: must be exactly this version
 * Java 1.8: must be exactly this version
 * Git Bash: version is not important - can skip this if you already have it
 * WinUtils: Windows only
 * Visual Studio Code/"VS Code": version is not important - can skip this if you already have it 
 
-Follow these [instructions for Windows](setup-windows.md), and these [instuctions for Macs](setup-mac.md).
+Note: It is possible you already have other/more recent versions of Python and Java already on your computer (Java 1.8 came out in 2014!). However, it is very important to use exactly these versions: lots of data engineering projects were built off of Java 1.8, and these versions need to be compatible with the versions of the AWS libraries we will be using. You will encounter lots of errors - some obvious, some tricky ("UnsatisifedLinkError"? "ClassDefNotFound?") if your versions of Java, Python, and AWS libraries are not correctly in sync!  Other tools we will use (VS Code, Git) are not as sensitive, and if you already have these on your computer, whatever versions you have are likely fine.
 
-Then set up:
+
+### Environment Setup - Environment variables
 
 * Environment variables relating to Java/Python/Spark
 * A Python virtual environment
 * VS Code
 
-And finally execute:
 
-* A  simple Spark program to make sure your environment on your computer is set up for Spark.
+### Environment Setup - Verification
+To verify your Spark environment is setup correctly, you will execute simple Spark program.
 
-Follow the setup instructions specific to your OS.
 
-Note: It is possible you already have other/more recent versions of Python and Java already on your computer (Java 1.8 came out in 2014!). However, it is very important to use exactly these versions: lots of data engineering projects were built off of Java 1.8, and these versions need to be compatible with the versions of the AWS libraries we will be using. You will encounter lots of errors - some obvious, some tricky ("UnsatisifedLinkError"? "ClassDefNotFound?") if your versions of Java, Python, and AWS libraries are not correctly in sync!
-
-Other tools we will use (VS Code, Git) are not as sensitive, and if you already have these on your computer, whatever versions you have are likely fine.
-
-### How to determine package versions
+### Environment Setup - Why so specific?
 
 If you want the gory details of why we must run with:
 

--- a/week1_welcome/README.md
+++ b/week1_welcome/README.md
@@ -1,12 +1,14 @@
 # Hours with Experts - Week 1: Environment Setup
 
-To set up your environment, we are going to install:
+To set up your environment, we are going to install the following:
 
-* Python 3.10: must be exactly this version - [install instructions](week1_welcome/setup-windows.md#installing-python)
+* Python 3.10: must be exactly this version
 * Java 1.8: must be exactly this version
 * Git Bash: version is not important - can skip this if you already have it
 * WinUtils: Windows only
 * Visual Studio Code/"VS Code": version is not important - can skip this if you already have it 
+
+Follow these [instructions for Windows](setup-windows.md), and these [instuctions for Macs](setup-mac.md).
 
 Then set up:
 

--- a/week1_welcome/README.md
+++ b/week1_welcome/README.md
@@ -2,7 +2,7 @@
 
 To set up your environment, we are going to install:
 
-* Python 3.10: must be exactly this version
+* Python 3.10: must be exactly this version - [install instructions](week1_welcome/setup-windows.md#installing-python)
 * Java 1.8: must be exactly this version
 * Git Bash: version is not important - can skip this if you already have it
 * WinUtils: Windows only

--- a/week1_welcome/setup-windows.md
+++ b/week1_welcome/setup-windows.md
@@ -4,21 +4,26 @@ Note: It is possible you already have other/more recent versions of Python and J
 
 ## Installing Python
 
-Navigate to https://www.python.org/downloads/windows and find the "Windows installer (64-bit)" for 3.10.11.
+1. Navigate to the [V3.10.11 downloads page](https://www.python.org/downloads/release/python-31011/) and download "Windows installer (64-bit)" for 3.10.11
+<br/>OR<br/>directly [download the file through this link](https://www.python.org/ftp/python/3.10.11/python-3.10.11-amd64.exe)
+2. Run the executable and complete the Python installation process.
+3. After completion, there is one extra step you may need to take to make sure Python is working. By default, Windows will attempt to install Python from the Windows store instead of executing your program when `python` is executed from the command line. To fix this:
+    1. Type `Manage app execution aliases` in the Windows search bar
+    2. Make sure the 2 Python options are disabled:
+        * "App Installer/python.exe"
+        * "App Installer/python3.exe"
 
-![Alt text](install-python-windows-1.png)
+4. To test your Python installation, open a command prompt and type "python --version". You should be greeted with a Python command line prompt matching the version you just installed.
+```
+c:\Users\you>python --version
+3.10.11
+```
+Q: What if it doesnt work?<br/>
+A: If you have newer versions of Python installed you may see a higher version of Python reported.
 
-Download the 64 bit Microsoft installer. Run the executable to start the Python installation process.
-
-
-After completion, there is one extra step you may need to take to make sure Python is working. By default, Windows will attempt to install Python from the Windows store instead of executing your program when `python` is executed from the command line. To fix this:
-
-1. Type `Manage app execution aliases` in the Windows search bar
-2. Make sure the 2 Python options are disabled:
-    * "App Installer/python.exe"
-    * "App Installer/python3.exe"
-
-After this is complete, open a command prompt and type "python". You should be greeted with a Python command line prompt matching the version you just installed.
+Attempt these remedies and return to step 4 above:
+- Uninstall other versions of Python
+- Remove conflicting PATH entries (dont forget to restart your command prompt before outputting the Python version again)
 
 ## Install Java 1.8
 Navigate to https://adoptium.net/download/:


### PR DESCRIPTION
Adding install instructions links so the week 1 readme more directly points to Windows and Mac readmes.  Also went through the Python install portion and noticed my previously installed version of Python was causing conflicts.