### PR TITLE
Exit configure script on incorrect java version in JAVA_HOME

### DIFF
--- a/week1_welcome/Configure-Linux.sh
+++ b/week1_welcome/Configure-Linux.sh
@@ -92,6 +92,7 @@ else
       echo -e "${RED}== Incorrect version of Java in JAVA_HOME."
       echo -e "Should be one of these in /usr/lib/jvm${NC}"
       ls /usr/lib/jvm
+      exit
    fi
 fi
 


### PR DESCRIPTION
Currently, the Configure_Linux.sh script exits with an error message on any failed checks, except when checking the java version in the JAVA_HOME variable. On this check the script will show an error message, then continue to Miniconda3 installation, hiding the error message. The script can then end with a message "all checks passed -- YOU ARE GOOD", despite the JAVA_HOME variable not being set correctly. 

This commit adds an "exit" command to that check so that the script fails after the error message is sent, and won't continue until the variable is set correctly. 